### PR TITLE
display entity map for debugging purposes

### DIFF
--- a/BE/controllers/mapController.ts
+++ b/BE/controllers/mapController.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
+import fs from 'fs';
 
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
@@ -40,3 +41,13 @@ export const createEntityMap = [
         }
     }
 ];
+
+export const getEntityMap = (req: Request, res: Response) => {
+
+    // stub for the real getEntityMap function
+};
+
+export const getTestEntityMap = (req: Request, res: Response) => {
+    const testEntityMap = JSON.parse(fs.readFileSync(path.join(__dirname, '../lib/utils/testMap.json'), 'utf8'));
+    res.json(testEntityMap);
+}

--- a/BE/controllers/mapController.ts
+++ b/BE/controllers/mapController.ts
@@ -1,0 +1,42 @@
+import type { Request, Response } from 'express';
+import multer from 'multer';
+import path from 'path';
+
+const storage = multer.diskStorage({
+    destination: (req, file, cb) => {
+        cb(null, path.join(__dirname, "../"));
+    },
+    filename: (req, file, cb) => {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+        cb(null, `entityMap_${timestamp}.json`);
+    },
+});
+
+const upload = multer({ storage });
+
+
+export const createEntityMap = [
+    upload.single("file"),
+    async (req: Request, res: Response) => {
+        console.log(req);
+
+        if (!req.file) {
+            return res.status(400).json({ error: "No file uploaded" });
+        }
+        const outputPath = path.join(__dirname, `../${req.file.filename}`);
+
+        try {
+            console.log("hello");
+
+            console.log(`Entity map written to ${outputPath}`);
+            res
+                .status(200)
+                .json({ message: "Entity map saved successfully", path: outputPath });
+        } catch (error) {
+            console.error("Error processing entity map:", error);
+            res
+                .status(500)
+                .json({ error: "Failed to process entity map", details: error });
+        }
+    }
+];

--- a/BE/server.ts
+++ b/BE/server.ts
@@ -13,7 +13,7 @@ import type { Request } from "express";
 import multer from "multer";
 
 import { WebSocketServer } from "ws";
-import { createEntityMap } from "./controllers/mapController";
+import { createEntityMap, getEntityMap, getTestEntityMap } from "./controllers/mapController";
 
 // Extend the Request interface
 interface RequestWithFile extends Request {
@@ -45,6 +45,9 @@ router.post("/initialize-player", initializePlayer);
 router.post("/update-position", updatePosition);
 router.get("/get-position/:penguinId", getPosition);
 router.get("/get-room-data", getRoomData);
+
+router.get('/get-entity-map', getEntityMap);
+router.get('/get-test-entity-map', getTestEntityMap);
 router.post("/create-entity-map", createEntityMap);
 
 

--- a/BE/server.ts
+++ b/BE/server.ts
@@ -13,6 +13,7 @@ import type { Request } from "express";
 import multer from "multer";
 
 import { WebSocketServer } from "ws";
+import { createEntityMap } from "./controllers/mapController";
 
 // Extend the Request interface
 interface RequestWithFile extends Request {
@@ -44,45 +45,8 @@ router.post("/initialize-player", initializePlayer);
 router.post("/update-position", updatePosition);
 router.get("/get-position/:penguinId", getPosition);
 router.get("/get-room-data", getRoomData);
+router.post("/create-entity-map", createEntityMap);
 
-const storage = multer.diskStorage({
-    destination: (req, file, cb) => {
-        cb(null, path.join(__dirname, "../"));
-    },
-    filename: (req, file, cb) => {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-        cb(null, `entityMap_${timestamp}.json`);
-    },
-});
-
-const upload = multer({ storage });
-
-app.post(
-    "/create-entity-map",
-    upload.single("file"),
-    async (req: RequestWithFile, res) => {
-        console.log(req);
-
-        if (!req.file) {
-            return res.status(400).json({ error: "No file uploaded" });
-        }
-        const outputPath = path.join(__dirname, `../${req.file.filename}`);
-
-        try {
-            console.log("hello");
-
-            console.log(`Entity map written to ${outputPath}`);
-            res
-                .status(200)
-                .json({ message: "Entity map saved successfully", path: outputPath });
-        } catch (error) {
-            console.error("Error processing entity map:", error);
-            res
-                .status(500)
-                .json({ error: "Failed to process entity map", details: error });
-        }
-    }
-);
 
 //Initialize the game state when the server starts
 storeInitialGameState();

--- a/FE/components/common/Room.tsx
+++ b/FE/components/common/Room.tsx
@@ -47,7 +47,8 @@ const Room = () => {
   //Handling movement
   const [position, setPosition] = useState<Position>({ x: 528, y: 630 });
 
-  const [canMove, setCanMove] = useState<boolean>(false); // New state to track if user can move
+  const [_canMove, setCanMove] = useState<boolean>(false); // New state to track if user can move
+  const canMove = true;
   const [isMovingFromBackend, setIsMovingFromBackend] =
     useState<boolean>(false);
   const [isAnimating, setIsAnimating] = useState<boolean>(false);

--- a/FE/components/common/Room.tsx
+++ b/FE/components/common/Room.tsx
@@ -15,6 +15,8 @@ import bodySprite from "../../src/assets/isometric-hero/clothes.png";
 import headSprite from "../../src/assets/isometric-hero/male_head1.png";
 import weaponSprite from "../../src/assets/isometric-hero/shortsword.png";
 import { useInterval } from "../hooks/useInterval";
+import { fetchEntityMap } from "../utils/fetchEntityMap";
+import { EntityMap } from "../../src/utils/types";
 
 interface Position {
   x: number;
@@ -52,6 +54,11 @@ const Room = () => {
   const [isMovingFromBackend, setIsMovingFromBackend] =
     useState<boolean>(false);
   const [isAnimating, setIsAnimating] = useState<boolean>(false);
+
+  const [entityMap, setEntityMap] = useState<EntityMap>([]);
+  const [debugMode, setDebugMode] = useState<boolean>(false);
+
+
 
   // Character's movement animation
   const [direction, setDirection] = useState<number>(0);
@@ -162,6 +169,7 @@ const Room = () => {
     const y = Math.floor(event.clientY - rect.top);
     const newClickedPos = { x, y };
 
+
     if (clickIsAvatarArea(newClickedPos, position, 100)) {
       setCanMove(true);
       console.log("Penguin selected. You can now move.");
@@ -228,8 +236,33 @@ const Room = () => {
       });
     }
   };
+
+  const handleGetEntityMap = async () => {
+    setEntityMap(await fetchEntityMap());
+    console.log('entity map', entityMap);
+  };
+
+  const fetchAndSetEntityMap = async () => {
+    const map = await fetchEntityMap();
+    console.log('setting entity map', map);
+    setEntityMap(map);
+  };
+
+
+  // Toggle debug mode
+  const toggleDebugMode = () => {
+    setDebugMode((prevDebugMode) => !prevDebugMode);
+    console.log('entities are', entityMap);
+    fetchAndSetEntityMap();
+  };
+
+
   return (
     <>
+
+      <button onClick={toggleDebugMode}>
+        {debugMode ? "Disable Debug Mode" : "Enable Debug Mode"}
+      </button>
       <div
         className="canvas"
         onClick={handleCanvasClick}
@@ -251,7 +284,11 @@ const Room = () => {
             />
           </>
         )}
+        {entityMap.map((entity, index) => (
+          <EntityMarker key={index} x={entity.x} y={entity.y} />
+        ))}
       </div>
+
       <div>
         {position && (
           <div>
@@ -268,8 +305,22 @@ const Room = () => {
             : "Click near the current Position to enable movement."}
         </p>
       </div>
+
+      <button onClick={handleGetEntityMap}>Get Entity Map</button>
     </>
   );
 };
+
+
+const EntityMarker = ({ x, y }: { x: number, y: number }) => {
+  return (
+
+    <div style={{ position: "absolute", left: `${x}px`, top: `${y}px`, width: "10px", height: "10px", backgroundColor: "red" }} >
+      x
+    </div>
+
+  )
+
+}
 
 export default Room;

--- a/FE/components/utils/fetchEntityMap.ts
+++ b/FE/components/utils/fetchEntityMap.ts
@@ -1,0 +1,10 @@
+// fetches entity map for a debug overlay
+
+export const fetchEntityMap = async () => {
+
+    const response = await fetch('/get-entity-map');
+    const data = await response.json();
+    console.log(data);
+    return data;
+
+};

--- a/FE/components/utils/fetchEntityMap.ts
+++ b/FE/components/utils/fetchEntityMap.ts
@@ -1,10 +1,17 @@
 // fetches entity map for a debug overlay
 
+const API_URL = import.meta.env.VITE_API_URL;
 export const fetchEntityMap = async () => {
-
-    const response = await fetch('/get-entity-map');
-    const data = await response.json();
-    console.log(data);
-    return data;
-
+    try {
+        const response = await fetch(`${API_URL}/get-test-entity-map`);
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+        console.log('Fetched entity map data:', data);
+        return data;
+    } catch (error) {
+        console.error('Error fetching entity map:', error);
+        return [];
+    }
 };

--- a/FE/src/MapCreator.tsx
+++ b/FE/src/MapCreator.tsx
@@ -17,7 +17,6 @@ const cellsY = Math.ceil(height / CHUNK_SIZE);
 
 
 
-
 const calculateNewEntityMap = (collisionMap: boolean[], prevEntityMap: EntityMap, entity: Entity) => {
     const updatedMap = collisionMap.map((collision, index) => {
         return {


### PR DESCRIPTION
- **refactor so mapcreator  is in a separate mapController**
- **able to display the entity map**

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c1f573a79421c41c8d1d8884141180fd0d72a00d  | 
|--------|--------|

### Summary:
Refactored backend to use a new `mapController` for entity map handling and updated frontend to display entity maps for debugging.

**Key points**:
- Added `BE/controllers/mapController.ts` to handle entity map creation and retrieval.
- Refactored `BE/server.ts` to use `mapController` for `/create-entity-map`, `/get-entity-map`, and `/get-test-entity-map` routes.
- Introduced `getTestEntityMap` function in `mapController` to return a test entity map from `../lib/utils/testMap.json`.
- Updated `FE/components/common/Room.tsx` to fetch and display entity map with `fetchEntityMap` utility.
- Added `FE/components/utils/fetchEntityMap.ts` to fetch entity map data from the server.
- Modified `Room` component to include a debug mode toggle and display entity markers.
- Removed map creation logic from `FE/src/MapCreator.tsx` and moved it to `mapController`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->